### PR TITLE
Fix static build

### DIFF
--- a/src/app/articles/rewriting-the-cosmos-kernel-in-rust/page.mdx
+++ b/src/app/articles/rewriting-the-cosmos-kernel-in-rust/page.mdx
@@ -1,5 +1,9 @@
 import { ArticleLayout } from '@/components/ArticleLayout'
 
+export default function ArticlePage({ children }) {
+  return <ArticleLayout article={article}>{children}</ArticleLayout>
+}
+
 export const article = {
   author: 'Adam Wathan',
   date: '2022-07-14',
@@ -13,7 +17,6 @@ export const metadata = {
   description: article.description,
 }
 
-export default (props) => <ArticleLayout article={article} {...props} />
 
 When we released the first version of cosmOS last year, it was written in Go. Go is a wonderful programming language with a lot of benefits, but it’s been a while since I’ve seen an article on the front page of Hacker News about rewriting some important tool in Go and I see articles on there about rewriting things in Rust every single week.
 


### PR DESCRIPTION
## Summary
- adjust `ArticlePage` component to avoid dynamic props causing export error

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6843185d993083229d0e6c4a9a093ecb