### PR TITLE
Add apps page listing applications

### DIFF
--- a/src/app/apps/page.jsx
+++ b/src/app/apps/page.jsx
@@ -1,0 +1,59 @@
+import Image from 'next/image'
+
+import { Card } from '@/components/Card'
+import { SimpleLayout } from '@/components/SimpleLayout'
+import logoPlanetaria from '@/images/logos/planetaria.svg'
+import logoAnimaginary from '@/images/logos/animaginary.svg'
+import logoHelioStream from '@/images/logos/helio-stream.svg'
+
+const apps = [
+  {
+    name: 'Planetaria',
+    subtitle: 'Explore the universe from your phone.',
+    link: {
+      href: '#',
+    },
+    logo: logoPlanetaria,
+  },
+  {
+    name: 'Animaginary',
+    subtitle: 'Bring your stories to life with animation.',
+    link: {
+      href: '#',
+    },
+    logo: logoAnimaginary,
+  },
+  {
+    name: 'HelioStream',
+    subtitle: 'Stream video across the galaxy.',
+    link: {
+      href: '#',
+    },
+    logo: logoHelioStream,
+  },
+]
+
+export const metadata = {
+  title: 'Apps',
+  description: 'The apps I\'ve built and maintain.',
+}
+
+export default function Apps() {
+  return (
+    <SimpleLayout title="Apps" intro="The apps I\'ve built and maintain.">
+      <ul role="list" className="grid grid-cols-1 gap-x-12 gap-y-16 sm:grid-cols-2 lg:grid-cols-3">
+        {apps.map((app) => (
+          <Card as="li" key={app.name}>
+            <div className="relative z-10 flex h-12 w-12 items-center justify-center rounded-full bg-white shadow-md ring-1 shadow-zinc-800/5 ring-zinc-900/5 dark:border dark:border-zinc-700/50 dark:bg-zinc-800 dark:ring-0">
+              <Image src={app.logo} alt="" className="h-8 w-8" unoptimized />
+            </div>
+            <h2 className="mt-6 text-base font-semibold text-zinc-800 dark:text-zinc-100">
+              <Card.Link href={app.link.href}>{app.name}</Card.Link>
+            </h2>
+            <Card.Description>{app.subtitle}</Card.Description>
+          </Card>
+        ))}
+      </ul>
+    </SimpleLayout>
+  )
+}

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -23,6 +23,7 @@ export function Footer() {
               <div className="flex flex-wrap justify-center gap-x-6 gap-y-1 text-sm font-medium text-zinc-800 dark:text-zinc-200">
                 <NavLink href="/about">About</NavLink>
                 <NavLink href="/projects">Projects</NavLink>
+                <NavLink href="/apps">Apps</NavLink>
                 <NavLink href="/speaking">Speaking</NavLink>
                 <NavLink href="/uses">Uses</NavLink>
               </div>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -116,6 +116,7 @@ function MobileNavigation(props) {
             <MobileNavItem href="/about">About</MobileNavItem>
             <MobileNavItem href="/articles">Articles</MobileNavItem>
             <MobileNavItem href="/projects">Projects</MobileNavItem>
+            <MobileNavItem href="/apps">Apps</MobileNavItem>
             <MobileNavItem href="/speaking">Speaking</MobileNavItem>
             <MobileNavItem href="/uses">Uses</MobileNavItem>
           </ul>
@@ -155,6 +156,7 @@ function DesktopNavigation(props) {
         <NavItem href="/about">About</NavItem>
         <NavItem href="/articles">Articles</NavItem>
         <NavItem href="/projects">Projects</NavItem>
+        <NavItem href="/apps">Apps</NavItem>
         <NavItem href="/speaking">Speaking</NavItem>
         <NavItem href="/uses">Uses</NavItem>
       </ul>


### PR DESCRIPTION
## Summary
- add Apps page to showcase applications
- link Apps page in navigation and footer

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68431fc25f448322965453634daecf45